### PR TITLE
getLatestSource path on Windows

### DIFF
--- a/src/main/java/com/springml/sftp/client/SFTPClient.java
+++ b/src/main/java/com/springml/sftp/client/SFTPClient.java
@@ -130,7 +130,7 @@ public class SFTPClient {
         for (int i = 0, size = ls.size(); i < size; i++) {
             LsEntry entry = (LsEntry) ls.get(i);
             int modTime = entry.getAttrs().getMTime();
-            if (latestModTime < modTime) {
+            if (!entry.getAttrs().isDir() && latestModTime < modTime) {
                 latestModTime = modTime;
                 fileName = entry.getFilename();
             }

--- a/src/main/java/com/springml/sftp/client/SFTPClient.java
+++ b/src/main/java/com/springml/sftp/client/SFTPClient.java
@@ -115,6 +115,10 @@ public class SFTPClient {
     private String getLatestSource(ChannelSftp sftpChannel, String source) throws Exception {
         Vector ls = sftpChannel.ls(source);
 
+        if (!source.endsWith("/") && ls.size() > 1) {
+            source = source + "/";
+        }
+
         String basePath = FilenameUtils.getPath(source);
         if (!basePath.startsWith("/")) {
             basePath = "/" + basePath;
@@ -132,7 +136,7 @@ public class SFTPClient {
             }
         }
 
-        return FilenameUtils.concat(basePath, fileName);
+        return basePath.concat(fileName);
     }
 
     private String getLatestLocalSource(String source) throws Exception {


### PR DESCRIPTION
- FilenameUtils.concat changes path separator to local default value (issue on Windows)
- If remote path is a folder, include separator at the end